### PR TITLE
Update install documents more Python 3 friendly.

### DIFF
--- a/doc-source/awscli-install-linux-python.md
+++ b/doc-source/awscli-install-linux-python.md
@@ -9,6 +9,13 @@ If your distribution did not come with Python, or came with an older version, in
    ```
    $ python --version
    ```
+
+   or
+
+   ```
+   $ python3 --version
+   ```
+
 **Note**  
 If your Linux distribution came with Python, you may need to install the Python developer package in order to get the headers and libraries required to compile extensions and install the AWS CLI\. Install the developer package \(typically named python\-dev or python\-devel\) using your package manager\.
 

--- a/doc-source/awscli-install-linux.md
+++ b/doc-source/awscli-install-linux.md
@@ -17,7 +17,7 @@ If you don't have pip, check to see which version of Python is installed\.
 $ python --version
 ```
 
-**or**
+or
 
 ```
 $ python3 --version
@@ -50,6 +50,12 @@ If you don't have `pip`, install `pip` with the script provided by the Python Pa
 
    ```
    $ python get-pip.py --user
+   ```
+
+   or
+
+   ```
+   $ python3 get-pip.py --user
    ```
 
 1. Add the executable path to your PATH variable: `~/.local/bin`

--- a/doc-source/cli-install-macos.md
+++ b/doc-source/cli-install-macos.md
@@ -16,7 +16,7 @@ You can install the latest version of Python and pip and then use them to instal
 
 **To install the AWS CLI on macOS**
 
-1. Download and install Python 3\.6 from the [downloads page](https://www.python.org/downloads/release/python-361/) of [Python\.org](https://www.python.org)\.
+1. Download and install Python 3\.6 from the [downloads page](https://www.python.org/downloads/release/python-364/) of [Python\.org](https://www.python.org)\.
 
 1. Install `pip` with the script provided by the Python Packaging Authority\.
 


### PR DESCRIPTION
As PyPI download stats [1], many Ubuntu 16.04 users install
awscli with Python 2.7.  But Ubuntu 16.04 provides only Python 3
by default.

Maybe, document should be more explicit for `python3` command.


[1]: https://bigquery.cloud.google.com/table/the-psf:pypi.downloads