### PR TITLE
Update cli-install-macos.md

### DIFF
--- a/doc-source/cli-install-macos.md
+++ b/doc-source/cli-install-macos.md
@@ -28,7 +28,7 @@ You can install the latest version of Python and pip and then use them to instal
 1. Use `pip` to install the AWS CLI\.
 
    ```
-   $ pip3 install awscli --upgrade --user
+   $ pip install awscli --upgrade --user
    ```
 
 1. Verify that the AWS CLI is installed correctly\.
@@ -43,7 +43,7 @@ You can install the latest version of Python and pip and then use them to instal
 To upgrade to the latest version, run the installation command again:
 
 ```
-$ pip3 install awscli --upgrade --user
+$ pip install awscli --upgrade --user
 ```
 
 ## Adding the AWS CLI Executable to your Command Line Path<a name="awscli-install-osx-path"></a>


### PR DESCRIPTION
Misspelled word, pip was spelled as pip3 in two locations.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
