### PR TITLE
cli-http-proxy.md: Add note about os.environ lowercase precedence

### DIFF
--- a/doc-source/cli-http-proxy.md
+++ b/doc-source/cli-http-proxy.md
@@ -54,3 +54,6 @@ $ export NO_PROXY=169.254.169.254
 ```
 > set NO_PROXY=169.254.169.254
 ```
+
+**Note**  
+Uppercase environment variables mentioned in this article are overriden by their lowercase version.


### PR DESCRIPTION
*Issue:*

Lowercase environment variables related to the AWS CLI proxy configuration take precedence over their Uppercase equivalent that the documentation though suggests to use.

See the discussion here on the requests repository: https://github.com/requests/requests/issues/4579#issuecomment-379795810

*Description of changes:*

Uppercase is a convention for environment variables, however it seems relevant to add a note related to the underlying behavior of this third-party library, as it is a potential source of errors for users.

Examples:
```
$ export HTTPS_PROXY=0.0.0.0:80
$ aws ec2 describe-instances --region=eu-west-2

HTTPSConnectionPool(host='ec2.eu-west-2.amazonaws.com', port=443): Max retries exceeded with url: / (Caused by ProxyError('Cannot connect to proxy.', error(111, 'Connection refused')))

$ export https_proxy=''
$ ec2 describe-instances --region=eu-west-2
{
    "Reservations": []
}

$ printenv|grep -i https
https_proxy=
HTTPS_PROXY=0.0.0.0:80
```