### PR TITLE
Update cli-configure-profiles.md

### DIFF
--- a/doc_source/cli-configure-profiles.md
+++ b/doc_source/cli-configure-profiles.md
@@ -54,7 +54,7 @@ Setting the environment variable changes the default profile until the end of yo
 **Windows**
 
 ```
-C:\> setx AWS_DEFAULT_PROFILE=user2
+C:\> setx AWS_DEFAULT_PROFILE user2
 ```
 
 Using `[set](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1)` to set an environment variable changes the value used until the end of the current command prompt session, or until you set the variable to a different value\. Using [https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx) to set an environment variable changes the value used in both the current command shell and all command shells that you create after running the command\. It does ***not*** affect other command shells that are already running at the time you run the command\.


### PR DESCRIPTION
The WIndows command for setting an environment variable has an equals sign, which throws a syntax error. The correct syntax with key <space> value.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
