### PR TITLE
Don't think you need the word "profile" in the Profile Name for CLI C…

### DIFF
--- a/doc_source/cli-configure-role.md
+++ b/doc_source/cli-configure-role.md
@@ -7,7 +7,7 @@ You can configure the AWS Command Line Interface \(AWS CLI\) to use an IAM role 
 The following example shows a role profile named `marketingadmin`\. If you run commands with `--profile marketingadmin` \(or specify it with the [AWS\_DEFAULT\_PROFILE environment variable](cli-configure-envvars.md)\), then the CLI uses the permissions assigned to the profile `user1` to assume the role with the Amazon Resource Name \(ARN\) `arn:aws:iam::123456789012:role/marketingadminrole`\. You can run any operations that are allowed by the permissions assigned to that role\.
 
 ```
-[profile marketingadmin]
+[marketingadmin]
 role_arn = arn:aws:iam::123456789012:role/marketingadminrole
 source_profile = user1
 ```


### PR DESCRIPTION
…onfigs

This confused me when referencing this example for using an assumed role and referencing that role from a profile. The command below doesn't work if you include "profile" in the actual profile name:

aws s3 ls --profile marketingadmin

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
