### PR TITLE
Update cli-configure-proxy.md

### DIFF
--- a/doc_source/cli-configure-proxy.md
+++ b/doc_source/cli-configure-proxy.md
@@ -20,9 +20,9 @@ $ export HTTPS_PROXY=http://proxy.example.com:5678
 
 ```
 C:\> setx HTTP_PROXY http://10.15.20.25:1234
-C:\> setx HTTP_PROXY=http://proxy.example.com:1234
-C:\> setx HTTPS_PROXY=http://10.15.20.25:5678
-C:\> setx HTTPS_PROXY=http://proxy.example.com:5678
+C:\> setx HTTP_PROXY http://proxy.example.com:1234
+C:\> setx HTTPS_PROXY http://10.15.20.25:5678
+C:\> setx HTTPS_PROXY http://proxy.example.com:5678
 ```
 
 ## Authenticating to a Proxy<a name="cli-configure-proxy-auth"></a>
@@ -40,7 +40,7 @@ $ export HTTPS_PROXY=http://username:password@proxy.example.com:5678
 
 ```
 C:\> setx HTTP_PROXY http://username:password@proxy.example.com:1234
-C:\> setx HTTPS_PROXY=http://username:password@proxy.example.com:5678
+C:\> setx HTTPS_PROXY http://username:password@proxy.example.com:5678
 ```
 
 **Note**  


### PR DESCRIPTION
On Windows "set" command require an equal sign, the "setx" command does not. Corrections make the commands actually work on Windows.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
