### PR TITLE
Update install-cliv2-linux-mac.md

### DIFF
--- a/doc_source/install-cliv2-linux-mac.md
+++ b/doc_source/install-cliv2-linux-mac.md
@@ -111,7 +111,7 @@ The preview release of the AWS CLI version 2 names the symlink `aws2` to enable 
 
 ## Upgrading<a name="cliv2-linux-mac-upgrade"></a>
 
-To upgrade your copy of the AWS CLI version 2, run the same steps that you used to install it, but this time include the `--update` or `-u` option on the `install` command line\. If the installer finds an existing version of the AWS CLI version 2 in the target installation folder and the `--upgrade` option isn't used, the install fails\.
+To upgrade your copy of the AWS CLI version 2, run the same steps that you used to install it, but this time include the `--update` or `-u` option on the `install` command line\. If the installer finds an existing version of the AWS CLI version 2 in the target installation folder and the `--update` option isn't used, the install fails\.
 
 Find the symlink that the installer created\. This gives you the path to use with the `--bin-dir` parameter\.
 


### PR DESCRIPTION
Replaced reference to --upgrade with proper --update parameter.

*Issue #, if available:*
See [Upgrading](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux-mac.html#cliv2-linux-mac-upgrade).

Paragraph states "If the installer finds an existing version of the AWS CLI version 2 in the target installation folder and the --upgrade option isn't used, the install fails".

It should say "the --update option"

*Description of changes:*
Replace --upgrade with --update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
