### PR TITLE
Update Boolean Type to Heading

### DIFF
--- a/doc_source/cli-usage-parameters-types.md
+++ b/doc_source/cli-usage-parameters-types.md
@@ -38,7 +38,9 @@ One or more strings separated by spaces\. If any of the string items contain a s
 $ aws ec2 describe-spot-price-history --instance-types m1.xlarge m1.medium
 ```
 
- **Boolean** – Binary flag that turns an option on or off\. For example, `ec2 describe-spot-price-history` has a Boolean `--dry-run` parameter that, when specified, validates the query with the service without actually running the query\. 
+ ## Boolean<a name="parameter-type-boolean"></a>
+ 
+Binary flag that turns an option on or off\. For example, `ec2 describe-spot-price-history` has a Boolean `--dry-run` parameter that, when specified, validates the query with the service without actually running the query\. 
 
 ```
 $ aws ec2 describe-spot-price-history --dry-run


### PR DESCRIPTION
*Issue #: none*

*Description of changes:*

The Boolean type section is highlighted as bold and gets lost. It appears as if it is a sub-type of list. This change makes it the same heading level as the other types and provides a link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
