### PR TITLE
Remove /usr/local/aws-cli for complete uninstall

### DIFF
--- a/doc_source/install-cliv2-linux.md
+++ b/doc_source/install-cliv2-linux.md
@@ -161,6 +161,7 @@ To uninstall the AWS CLI version 2, run the following commands\.
    ```
    $ sudo rm /usr/local/bin/aws
    $ sudo rm /usr/local/bin/aws_completer
+   $ sudo rm /usr/local/aws-cli
    ```
 
 1. Delete the `--install-dir` directory\. If your user account has write permission to this directory, you don't need to use `sudo`\.


### PR DESCRIPTION
Uninstalling and re-installing aws-cli v2 required removing `/usr/local/aws-cli` first

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
