### PR TITLE
Fix typo in docker installation instructions

### DIFF
--- a/doc_source/install-cliv2-docker.md
+++ b/doc_source/install-cliv2-docker.md
@@ -63,7 +63,7 @@ You can use two types of tags:
 + `<major.minor.patch>` – Defines a specific version of the AWS CLI version 2 for the Docker image\. If you plan to use the Docker image in production, we recommend you use a specific version of the AWS CLI version 2 to ensure backward compatibility\. For example, to run version 2\.0\.6, append the version to the container image name\.
 
   ```
-  $ docker run --rm -it amazon/aws-cli:2.0.366 command
+  $ docker run --rm -it amazon/aws-cli:2.0.6 command
   ```
 
 ## Update to the latest Docker image<a name="cliv2-docker-update"></a>


### PR DESCRIPTION
*Description of changes:*

Make the version in example consistent with the text above.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
