### PR TITLE
fix typo for Windows alias

### DIFF
--- a/doc_source/install-cliv2-docker.md
+++ b/doc_source/install-cliv2-docker.md
@@ -237,7 +237,7 @@ To shorten the Docker `aws` command, we suggest you use your operating system's 
 #### [ Windows ]
 
   ```
-  C:\> doskey aws test=docker run --rm -it -v %userprofile%\.aws:/root/.aws -v %cd%:/aws amazon/aws-cli $*
+  C:\> doskey aws=docker run --rm -it -v %userprofile%\.aws:/root/.aws -v %cd%:/aws amazon/aws-cli $*
   ```
 
 ------


### PR DESCRIPTION
Windows doskey gives an unhelpful `Invalid macro definition.` with the command provided. This patch fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
