### PR TITLE
drop sudo from example of how to run without sudo

### DIFF
--- a/doc_source/install-cliv2-linux.md
+++ b/doc_source/install-cliv2-linux.md
@@ -154,7 +154,7 @@ sudo ./aws/install
      The default value is `/usr/local/bin`\.
 
    ```
-   $ sudo ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
+   $ ./aws/install -i /usr/local/aws-cli -b /usr/local/bin
    ```
 
 1. Confirm the installation\.


### PR DESCRIPTION
*Issue #, if available:* no issue; slight confusion in finding `sudo` in the example under how to run without using sudo.

*Description of changes:* removed `sudo` from start of command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
