### PR TITLE
Fix docker run command flags

### DIFF
--- a/doc_source/install-cliv2-docker.md
+++ b/doc_source/install-cliv2-docker.md
@@ -37,7 +37,7 @@ $ docker run --rm -it amazon/aws-cli command
 ```
 
 This is how the command functions:
-+ `docker run --rm --it amazon/aws-cli` – The equivalent of the `aws` executable\. Each time you run this command, Docker spins up a container of your downloaded `amazon/aws-cli` image, and executes your `aws` command\. By default, the Docker image uses the latest version of the AWS CLI version 2\.
++ `docker run --rm -it amazon/aws-cli` – The equivalent of the `aws` executable\. Each time you run this command, Docker spins up a container of your downloaded `amazon/aws-cli` image, and executes your `aws` command\. By default, the Docker image uses the latest version of the AWS CLI version 2\.
 
   For example, to call the `aws --version` command in Docker, you run the following\.
 


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
Fix flags in example for `docker run` command. All other examples on this site use the correct `-it` flags. Here, `--it` was used which doesn't exist and results in an error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
