### PR TITLE
Update cli-configure-profiles.md

### DIFF
--- a/doc_source/cli-configure-profiles.md
+++ b/doc_source/cli-configure-profiles.md
@@ -54,7 +54,7 @@ $ export AWS_PROFILE=user1
 **Windows**
 
 ```
-C:\> setx AWS_PROFILE user1
+C:\> set AWS_PROFILE=user1
 ```
 
 Using `[set](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/set_1)` to set an environment variable changes the value used until the end of the current command prompt session, or until you set the variable to a different value\. 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

* Using `setx` on Windows (which does not affect the already running shell) causes quite a bit of confusion.
* `set` on Windows seems to be semantically similar to `export` on Linux and macOS and hence a better choice for documenting how to set the `AWS_PROFILE` environment variable



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
