### PR TITLE
Adjusted example of how to use change_ec2_instance_type

### DIFF
--- a/doc_source/cli-services-ec2-instance-type-script.md
+++ b/doc_source/cli-services-ec2-instance-type-script.md
@@ -25,7 +25,7 @@ This example is written as a function in the shell script file `change_ec2_insta
 
 ```
 $ source ./change_ec2_instance_type.sh
-$ ./change_ec2_instance_type -i *instance-id* -t new-type
+$ change_ec2_instance_type -i *instance-id* -t new-type
 ```
 
 For the full example and downloadable script files, see [Change Amazon EC2 Instance Type](https://github.com/awsdocs/aws-doc-sdk-examples/tree/master/aws-cli/bash-linux/ec2/change-ec2-instance-type) in the *AWS Code Examples Repository* on *GitHub*\.


### PR DESCRIPTION
`change_ec2_instance_type` is a function, not a script, so you don't need to use `./` in front of it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.