### PR TITLE
Add missing back quote on filter example

### DIFF
--- a/doc_source/cli-usage-filter.md
+++ b/doc_source/cli-usage-filter.md
@@ -559,7 +559,7 @@ The following example filters for the `VolumeIds` of all `Volumes` that have a s
 
 ```
 $ aws ec2 describe-volumes \
-    --query 'Volumes[?Size < 20].VolumeId'
+    --query 'Volumes[?Size < `20`].VolumeId'
 [
   "vol-2e410a47",
   "vol-a1b3c7nd"


### PR DESCRIPTION
Missing back quote on 20.

$ aws ec2 describe-volumes \
    --query 'Volumes[?Size < `20`].VolumeId'
[
  "vol-2e410a47",
  "vol-a1b3c7nd"
]

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
