### PR TITLE
Fix typo: Update cli-services-s3-commands.md

### DIFF
--- a/doc_source/cli-services-s3-commands.md
+++ b/doc_source/cli-services-s3-commands.md
@@ -161,7 +161,7 @@ The following example moves all objects from `s3://bucket-name/example` to `s3:/
 $ aws s3 mv s3://bucket-name/example s3://my-bucket/
 ```
 
-The following example moves a local file from your current working directory to the Amazon S3 bucket with the `s3 cp` command\.
+The following example moves a local file from your current working directory to the Amazon S3 bucket with the `s3 mv` command\.
 
 ```
 $ aws s3 mv filename.txt s3://bucket-name


### PR DESCRIPTION
Changed 'using command "cp"' where a command "mv" is used to also use "mv".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
