### PR TITLE
Windows PowerShell subcommand completion fix

### DIFF
--- a/doc_source/cli-configure-completion.md
+++ b/doc_source/cli-configure-completion.md
@@ -184,6 +184,9 @@ To enable command completion for PowerShell on Windows, complete the following s
    Register-ArgumentCompleter -Native -CommandName aws -ScriptBlock {
        param($commandName, $wordToComplete, $cursorPosition)
            $env:COMP_LINE=$wordToComplete
+           if ($env:COMP_LINE.Length -lt $cursorPosition){
+               $env:COMP_LINE=$env:COMP_LINE + " "
+           }
            $env:COMP_POINT=$cursorPosition
            aws_completer.exe | ForEach-Object {
                [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)


### PR DESCRIPTION
Fix for Powershell completion where subcommand/action are not completed if the user does not provide a prefix.

*Issue #, if available:*
N/A

*Description of changes:*
Subcommand completion works only if the user provides a prefix of the subcommand.
PS H:\> aws s3 c<tab>
completes as expected to
PS H:\> aws s3 cp

However, if the user does not provide a few characters from the subcommand, then the completion repeats the subcommand
PS H:\> aws s3 <tab>
results in 
PS H:\> aws s3 s3 
s3 s3

The expected result is to provide a list of subcommands 
PS H:\> aws s3
ls       website  cp       mv       rm       sync     mb       rb       presign

This appears to be due to PowerShell stripping the space at the end of the command line.  The proposed change appends a space if the COMP_POINT is larger than the length of the COMP_LINE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
