### PR TITLE
fix EC2 documentation link

### DIFF
--- a/doc_source/cli-services-ec2-instance-type-script.md
+++ b/doc_source/cli-services-ec2-instance-type-script.md
@@ -694,5 +694,5 @@ function generate_random_name {
 + [aws ec2 wait instance\-stopped](https://docs.aws.amazon.com/cli/latest/reference/ec2/wait/instance-stopped.html)
 
 **Other reference:**
-+ [Amazon Elastic Compute Cloud Documentation](https://docs.aws.amazon.com/https://docs.aws.amazon.com/ec2/)
++ [Amazon Elastic Compute Cloud Documentation](https://docs.aws.amazon.com/ec2/)
 + To view and contribute to AWS SDK and AWS CLI code examples, see the [AWS Code Examples Repository](https://github.com/awsdocs/aws-doc-sdk-examples/) on *GitHub*\.


### PR DESCRIPTION
Link doesn't navigate to docs correctly

Fixed the link


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
